### PR TITLE
Feature: Close the modal dialog more easily

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -262,11 +262,27 @@ document.addEventListener("DOMContentLoaded", async function () {
     }
     settingsModal.classList.add("active");
     settingsModal.style.display = "flex";
+    // Esc キーを押下して閉じる（キャンセル）
+    window.addEventListener("keydown", function (e) {
+      if (e.key === "Escape" && !e.isComposing) {
+        closeSettingsBtn.click();
+      }
+    }, { once: true });
   });
   closeSettingsBtn.addEventListener("click", function () {
     settingsModal.classList.remove("active");
     settingsModal.style.display = "none";
   });
+  // モーダルの外側をクリックして閉じる（キャンセル）
+  settingsModal.addEventListener("click", function () {
+    closeSettingsBtn.click();
+  });
+  // ただし、モーダルの本体をクリックしては閉じない
+  settingsModal
+    .querySelector(".modal-content")
+    .addEventListener("click", (e) => {
+      e.stopPropagation();
+    });
   setCurrentCenterBtn.addEventListener("click", function () {
     const c = map.getCenter();
     respawnLatInput.value = c.lat.toFixed(6);


### PR DESCRIPTION
この PR では、設定のモーダルダイアローグをより簡単に閉じるために、以下の機能追加を提案します。

- ダイアローグが表示されている状態で <kbd>Esc</kbd> を押下すると、ダイアローグは「閉じる」ボタンを押されたように閉じます。
- ダイアローグが表示されている状態でダイアローグ外の領域をクリックすると、ダイアローグは「閉じる」ボタンを押されたように閉じます。